### PR TITLE
Changing GitHub workflow to run once daily (previously, hourly) at 1800UTC.

### DIFF
--- a/.github/workflows/update_tables.yml
+++ b/.github/workflows/update_tables.yml
@@ -1,9 +1,9 @@
 name: JetBrains IDE Release Date Fetcher
 
 on:
-  # Run this workflow on a schedule; every hour.
+  # Run this workflow on a schedule; every day at 1800UTC.
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 18 * * *"
 
   # Allow a manually triggered execution of this workflow.
   workflow_dispatch:


### PR DESCRIPTION
# Summary

Changing GitHub workflow to run once daily (previously, hourly) at 1800UTC.

# Rational

As previously mentioned by @vicky17d (in [this PR from ~1 year ago](https://github.com/ChrisCarini/jetbrains-ide-release-dates/pull/2#discussion_r551503149)), running this hourly, while nice, is a bit excessive.

`1800` is not a randomly chosen time, but rather, data backed.

Looking at the historical commits by the `github-actions[bot]` user, >85% of the commits are in by 1800UTC.

```
┌─(ChrisCarini)──(2022-01-21 @ 18:46:00)──( ~/GitHub/jetbrains/jetbrains-ide-release-dates  (main) ) 
└─$ > git log --graph --pretty=format:'%ci %C(auto)%h%d (%cr) %cn <%ce> %s' | \grep "github-actions" | awk '{print $3}' | \grep ".*:.*" | awk -F: '{print $1}' | sort | uniq -c
   5 08
   3 09
   3 10
   8 11
  13 12
  17 13
  16 14
  16 15
  11 16
  18 17
   6 18
   4 19
   5 20
   2 21
```

![Screen Shot 2022-01-21 at 18 59 10](https://user-images.githubusercontent.com/6374067/150622384-7aa79d1b-92e3-4be1-850f-b47dc68d80ad.png)

As can be seen in the above graphic, ~91% of commits are made during or before the 18th hour (UTC). Hence, 1800 is chosen.